### PR TITLE
Account for build step converting ts to js files

### DIFF
--- a/examples/src/tests/template.json
+++ b/examples/src/tests/template.json
@@ -501,7 +501,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-06T21:04:25.615Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-07T20:49:08.173Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -561,7 +561,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-06T21:27:37.586Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-07T20:49:09.767Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -501,7 +501,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-06T21:04:25.552Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-07T20:49:13.966Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },


### PR DESCRIPTION
To avoid this error when compiling code using the imported package:

```
 Cannot find entry file at /node_modules/@connected-web/openapi-rest-api/library/dist/src/openapi/DefaultAuthorizer.ts
```