### PR TITLE
Avoid unnecessary bundling

### DIFF
--- a/examples/src/Resources.ts
+++ b/examples/src/Resources.ts
@@ -15,14 +15,14 @@ export class ExampleResources {
   scope: Construct
   stack: cdk.Stack
 
+  serviceBucket: s3.Bucket
+
   constructor (scope: Construct, stack: cdk.Stack) {
     this.scope = scope
     this.stack = stack
-  }
 
-  get serviceDataBucket (): s3.Bucket {
     const serviceBucketName = process.env.SERVICE_BUCKET_NAME ?? 'test-api-service-data-bucket'
-    return new s3.Bucket(this.stack, 'ExampleServiceBucket', {
+    this.serviceBucket = new s3.Bucket(this.stack, 'ExampleServiceBucket', {
       bucketName: serviceBucketName,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       versioned: true

--- a/examples/src/Resources.ts
+++ b/examples/src/Resources.ts
@@ -15,14 +15,14 @@ export class ExampleResources {
   scope: Construct
   stack: cdk.Stack
 
-  serviceBucket: s3.Bucket
+  serviceDataBucket: s3.Bucket
 
   constructor (scope: Construct, stack: cdk.Stack) {
     this.scope = scope
     this.stack = stack
 
     const serviceBucketName = process.env.SERVICE_BUCKET_NAME ?? 'test-api-service-data-bucket'
-    this.serviceBucket = new s3.Bucket(this.stack, 'ExampleServiceBucket', {
+    this.serviceDataBucket = new s3.Bucket(this.stack, 'ExampleServiceBucket', {
       bucketName: serviceBucketName,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       versioned: true

--- a/library/src/openapi/Function.ts
+++ b/library/src/openapi/Function.ts
@@ -70,7 +70,7 @@ export default class OpenAPIFunction {
       entry: routeEntryPoint,
       bundling: {
         minify: true,
-        externalModules: ['@aws-sdk/*', 'aws-sdk']
+        externalModules: ['@aws-sdk/*', 'aws-sdk', 'aws-cdk-lib', 'aws-lambda', 'constructs', 'source-map-support']
       }
     }
 

--- a/library/src/openapi/Function.ts
+++ b/library/src/openapi/Function.ts
@@ -70,7 +70,7 @@ export default class OpenAPIFunction {
       entry: routeEntryPoint,
       bundling: {
         minify: true,
-        externalModules: ['aws-sdk']
+        externalModules: ['@aws-sdk/*', 'aws-sdk']
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connected-web/openapi-rest-api",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "ISC",
       "workspaces": [
         "library",
@@ -18,7 +18,7 @@
     },
     "examples": {
       "name": "openapi-rest-api-example",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.282.0",
@@ -53,7 +53,7 @@
     },
     "library": {
       "name": "openapi-rest-api",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.282.0",


### PR DESCRIPTION
Avoid unnecessary bundling with: 
```ts
  externalModules: ['@aws-sdk/*', 'aws-sdk', 'aws-cdk-lib', 'aws-lambda', 'constructs', 'source-map-support']
```