### PR TITLE
Generate operationId based on REST signature

### DIFF
--- a/library/src/PackageIndex.ts
+++ b/library/src/PackageIndex.ts
@@ -5,6 +5,7 @@ import OpenAPIRestAPI, { Verifier } from './openapi/RestAPI'
 import { OpenAPIRouteMetadata } from './openapi/Routes'
 import { OpenAPIModelFactory } from './openapi/ModelFactory'
 import { corsHeaders, httpStatusCodes, lambdaResponse } from './openapi/Response'
+import { generateOperationId } from './openapi/Operations'
 
 export type OpenAPIVerifiers = Verifier[]
 
@@ -15,6 +16,10 @@ export const OpenAPIEnums = {
 
 export const OpenAPIHelpers = {
   lambdaResponse
+}
+
+export const OpenAPIOperations = {
+  generateOperationId
 }
 
 export {

--- a/library/src/openapi/Operations.ts
+++ b/library/src/openapi/Operations.ts
@@ -1,0 +1,20 @@
+export function generateOperationId (restSignature: string): string {
+  const method = restSignature.split(' ')[0].toUpperCase()
+  const path = restSignature.split(' ')[1]
+
+  const cleanedPath = path
+    .replace(/-/g, '/') // Replace any hypens with slashes
+    .replace(/\/+/g, '/') // Replace any repeating sequences of slashes with a single slash
+    .replace(/[^a-zA-Z0-9/]/g, '') // Remove any non-alphanumeric characters apart from slashes
+
+  let operationId = ''
+  const pathComponents = cleanedPath.split('/')
+  const capitalizedParts = pathComponents.map((component) => {
+    return component.charAt(0).toUpperCase() + component.slice(1)
+  })
+
+  const findDuplicateWords = /([A-z]+)\1/g
+  operationId = capitalizedParts.join('').replace(findDuplicateWords, '$1')
+
+  return method.toLowerCase() + operationId
+}

--- a/library/src/openapi/RestAPI.ts
+++ b/library/src/openapi/RestAPI.ts
@@ -8,6 +8,7 @@ import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatem
 
 import OpenAPIEndpoint from './Endpoint'
 import OpenAPIFunction from './Function'
+import { generateOperationId } from './Operations'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import path from 'path'
 import { OpenAPIRouteMetadata } from './Routes'
@@ -285,7 +286,10 @@ export default class OpenAPIRestAPI<R> extends Construct {
       throw new Error(`Unsupported HTTP method: ${methodKey}; supported keys are: ${Object.keys(supportedHttpMethods).join(', ')}`)
     }
 
-    const oapiFunction = new OpenAPIFunction(endpointMetaData.operationId)
+    endpointMetaData.restSignatureOverride = `${methodKey} ${path}`
+    const operationId = endpointMetaData.operationId ?? generateOperationId(endpointMetaData.restSignatureOverride)
+
+    const oapiFunction = new OpenAPIFunction(operationId)
     const lambda = oapiFunction.createNodeJSLambda(this, endpointMetaData.routeEntryPoint, endpointMetaData.lambdaConfig)
     endpointMetaData.grantPermissions(this, lambda, this.sharedResources)
     const endpoint = new OpenAPIEndpoint<OpenAPIFunction>(method, path, oapiFunction)

--- a/library/src/openapi/Routes.ts
+++ b/library/src/openapi/Routes.ts
@@ -2,6 +2,7 @@
 import { Construct } from 'constructs'
 import { NodejsFunction, NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs'
 import { MethodResponse, IModel } from 'aws-cdk-lib/aws-apigateway'
+import { generateOperationId } from './Operations'
 
 /**
  * This is the interface that all routes must implement
@@ -15,6 +16,11 @@ import { MethodResponse, IModel } from 'aws-cdk-lib/aws-apigateway'
  */
 export abstract class OpenAPIRouteMetadata<R> {
   /**
+   * Override the rest signature that is used to generate the default operationId
+   */
+  public restSignatureOverride?: string
+
+  /**
    * Grant permissions to the endpoint to access resources
    * @param scope      Construct scope - use to create new resources such as policies
    * @param endpoint   Lambda endpoint - use to grant permissions to the route to access resources
@@ -24,8 +30,12 @@ export abstract class OpenAPIRouteMetadata<R> {
 
   /**
    * The operationId is used to identify the endpoint in the OpenAPI spec
+   *
+   * If left unspecified it will be generated from the restSignature, e.g. 'METHOD /operation/path' => 'methodOperationPath'
    */
-  abstract get operationId (): string
+  public get operationId (): string | undefined {
+    return undefined
+  }
 
   /**
    * The restSignature is used to create a path in API Gateway to map to your endpoint handler
@@ -43,6 +53,10 @@ export abstract class OpenAPIRouteMetadata<R> {
    *   return 'DELETE /record/{recordId}'
    */
   public get restSignature (): string | undefined {
+    const { restSignatureOverride } = this
+    if (restSignatureOverride !== undefined) {
+      return generateOperationId(restSignatureOverride)
+    }
     return undefined
   }
 

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -434,11 +434,11 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "318383f7fcdd329443cd4fe147ab6ce6faf38126b8e531ea59733bf4178f2eb8.zip"
+          "S3Key": "18b246e63a4bf4eb166f64c2ba8c75b097cbaade4682c09076858812e0d28a01.zip"
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-10-16T14:34:45.335Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-10-16T16:35:56.490Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },

--- a/library/src/tests/unit/generatedOperationIds.test.ts
+++ b/library/src/tests/unit/generatedOperationIds.test.ts
@@ -1,0 +1,100 @@
+import { expect, describe, it, beforeAll } from '@jest/globals'
+
+import path from 'path'
+import * as cdk from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+import { OpenAPIRestAPI, OpenAPIRouteMetadata } from '../../PackageIndex'
+
+class StubResources {
+  bucket: any
+}
+
+class StubEndpoint extends OpenAPIRouteMetadata<StubResources> {
+  grantPermissions (scope: Construct, endpoint: any, resources: StubResources): void {}
+  get routeEntryPoint (): string { return path.join(__dirname, 'stub/handler.ts') }
+  get methodResponses (): any[] { return [] }
+}
+
+describe('Generated Operation IDs', () => {
+  let api: OpenAPIRestAPI<StubResources>
+  beforeAll(() => {
+    process.env.CREATE_CNAME_RECORD = 'true'
+    const app = new cdk.App()
+    const stack = new cdk.Stack(app, 'MyTestStack', {
+      env: { account: '123456789012', region: 'us-east-1' }
+    })
+    const sharedResources = new StubResources()
+    api = new OpenAPIRestAPI<StubResources>(stack, 'stub-app', {
+      Description: 'Stub API for testing Rest Signatures',
+      SubDomain: 'rest-signatures',
+      HostedZoneDomain: 'stub.test',
+      Verifiers: []
+    }, sharedResources)
+  })
+
+  it('should generate IDs for GET paths', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'GET /test': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('getTest')
+  })
+
+  it('should generate IDs for PUT paths', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'PUT /test': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('putTest')
+  })
+
+  it('should generate IDs for POST paths', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'POST /test': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('postTest')
+  })
+
+  it('should generate IDs for DELETE paths', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'DELETE /test': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('deleteTest')
+  })
+
+  it('should generate IDs for complex paths with parameters', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'GET /user/{userId}/history/{versionId}': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('getUserIdHistoryVersionId')
+  })
+
+  it('should generate IDs for complex paths with hyphens', () => {
+    const endpoint = new StubEndpoint()
+    expect(() => api.addEndpoints({ 'PUT /user-elaborate-data/create': endpoint })).not.toThrow()
+    const mostRecent = api.endpoints[api.endpoints.length - 1]
+    expect(mostRecent.value.operationId).toEqual('putUserElaborateDataCreate')
+  })
+
+  it('should generate a report in markdown format', () => {
+    const actual = api.generateReportMarkdown()
+    const expected = [
+      '# stub-app',
+      '',
+      'Stub API for testing Rest Signatures',
+      '',
+      'Registered URL: https://rest-signatures.stub.test',
+      '',
+      '## Endpoints',
+      '',
+      '| HTTP Method | Path | Operation ID |',
+      '| --- | --- | --- |',
+      '| GET | /test | getTest |',
+      '| PUT | /test | putTest |',
+      '| POST | /test | postTest |',
+      '| DELETE | /test | deleteTest |',
+      '| GET | /user/{userId}/history/{versionId} | getUserIdHistoryVersionId |',
+      '| PUT | /user-elaborate-data/create | putUserElaborateDataCreate |',
+      ''
+    ]
+    expect(actual.split('\n')).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Related to #5 

Should reduce amount of code required to create each endpoint; and help with duplicating stub endpoints when initially building APIs.