### PR TITLE
Add support for PATCH

### DIFF
--- a/examples/src/tests/template.json
+++ b/examples/src/tests/template.json
@@ -1,64 +1,15 @@
 {
   "Resources": {
-    "ExampleAPIPrivateApiRequestAuthorizerDB7A3947": {
-      "Type": "AWS::ApiGateway::Authorizer",
+    "ExampleServiceBucketFDFBB652": {
+      "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AuthorizerUri": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Fn::Select": [
-                  1,
-                  {
-                    "Fn::Split": [
-                      ":",
-                      {
-                        "Fn::GetAtt": [
-                          "PrivateAPIAuthorizer2400616B",
-                          "Arn"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              ":apigateway:",
-              {
-                "Fn::Select": [
-                  3,
-                  {
-                    "Fn::Split": [
-                      ":",
-                      {
-                        "Fn::GetAtt": [
-                          "PrivateAPIAuthorizer2400616B",
-                          "Arn"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "PrivateAPIAuthorizer2400616B",
-                  "Arn"
-                ]
-              },
-              "/invocations"
-            ]
-          ]
-        },
-        "IdentitySource": "method.request.header.Authorization",
-        "Name": "MyTestStackExampleAPIPrivateApiRequestAuthorizerEBBBC25A",
-        "RestApiId": {
-          "Ref": "ExampleAPI61CA833D"
-        },
-        "Type": "REQUEST"
-      }
+        "BucketName": "test-api-service-data-bucket",
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete"
     },
     "ExampleAPI61CA833D": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -116,7 +67,7 @@
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Retain"
     },
-    "ExampleAPIDeployment7211F28Ded8ef74cf942010ebffeb40cf4de6b24": {
+    "ExampleAPIDeployment7211F28D85e16ec536cef23a4a0b795026a9d392": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "Description": "Example API - https://github.com/connected-web/openapi-rest-api",
@@ -125,8 +76,14 @@
         }
       },
       "DependsOn": [
+        "ApiPayloadModel2BDE964E",
         "ApiResponseModel7ED3C248",
         "ExampleAPIOPTIONS3CB2EF6E",
+        "ExampleAPIreceivepayloadpathParamOPTIONS560DFB8E",
+        "ExampleAPIreceivepayloadpathParamPUTD17F19A1",
+        "ExampleAPIreceivepayloadpathParamD39EAFE4",
+        "ExampleAPIreceivepayloadOPTIONS8536B744",
+        "ExampleAPIreceivepayload318A0B3F",
         "ExampleAPIstatusGETB4B924D6",
         "ExampleAPIstatusOPTIONSEC7DF4E1",
         "ExampleAPIstatus12420EBC"
@@ -136,7 +93,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExampleAPIDeployment7211F28Ded8ef74cf942010ebffeb40cf4de6b24"
+          "Ref": "ExampleAPIDeployment7211F28D85e16ec536cef23a4a0b795026a9d392"
         },
         "RestApiId": {
           "Ref": "ExampleAPI61CA833D"
@@ -314,10 +271,7 @@
     "ExampleAPIstatusGETB4B924D6": {
       "Type": "AWS::ApiGateway::Method",
       "Properties": {
-        "AuthorizationType": "CUSTOM",
-        "AuthorizerId": {
-          "Ref": "ExampleAPIPrivateApiRequestAuthorizerDB7A3947"
-        },
+        "AuthorizationType": "NONE",
         "HttpMethod": "GET",
         "Integration": {
           "Credentials": {
@@ -372,6 +326,246 @@
         }
       }
     },
+    "ExampleAPIreceivepayload318A0B3F": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ExampleAPI61CA833D",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "receive-payload",
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadOPTIONS8536B744": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Authorization,content-type'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Credentials": "'true'"
+              },
+              "StatusCode": "204"
+            }
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }"
+          },
+          "Type": "MOCK"
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Credentials": true
+            },
+            "StatusCode": "204"
+          }
+        ],
+        "ResourceId": {
+          "Ref": "ExampleAPIreceivepayload318A0B3F"
+        },
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadpathParamD39EAFE4": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Ref": "ExampleAPIreceivepayload318A0B3F"
+        },
+        "PathPart": "{pathParam}",
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadpathParamOPTIONS560DFB8E": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "OPTIONS",
+        "Integration": {
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Authorization,content-type'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Credentials": "'true'"
+              },
+              "StatusCode": "204"
+            }
+          ],
+          "RequestTemplates": {
+            "application/json": "{ statusCode: 200 }"
+          },
+          "Type": "MOCK"
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Access-Control-Allow-Methods": true,
+              "method.response.header.Access-Control-Allow-Credentials": true
+            },
+            "StatusCode": "204"
+          }
+        ],
+        "ResourceId": {
+          "Ref": "ExampleAPIreceivepayloadpathParamD39EAFE4"
+        },
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadpathParamPUTApiPermissionMyTestStackExampleAPI8A72BB8EPUTreceivepayloadpathParamDEE49722": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ExampleAPIStorePayload1114E802",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:eu-west-2:1234567890:",
+              {
+                "Ref": "ExampleAPI61CA833D"
+              },
+              "/",
+              {
+                "Ref": "ExampleAPIDeploymentStagev1550204A9"
+              },
+              "/PUT/receive-payload/*"
+            ]
+          ]
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadpathParamPUTApiPermissionTestMyTestStackExampleAPI8A72BB8EPUTreceivepayloadpathParam08A6E985": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ExampleAPIStorePayload1114E802",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:eu-west-2:1234567890:",
+              {
+                "Ref": "ExampleAPI61CA833D"
+              },
+              "/test-invoke-stage/PUT/receive-payload/*"
+            ]
+          ]
+        }
+      }
+    },
+    "ExampleAPIreceivepayloadpathParamPUTD17F19A1": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "PUT",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ExampleAPIApiExecutionRoleF249491B",
+              "Arn"
+            ]
+          },
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:eu-west-2:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "ExampleAPIStorePayload1114E802",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": [
+          {
+            "ResponseModels": {
+              "application/json": {
+                "Ref": "ApiResponseModel7ED3C248"
+              }
+            },
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true,
+              "method.response.header.Access-Control-Allow-Origin": true,
+              "method.response.header.Access-Control-Allow-Credentials": true
+            },
+            "StatusCode": "200"
+          }
+        ],
+        "OperationName": "storePayload",
+        "RequestModels": {
+          "application/json": {
+            "Ref": "ApiPayloadModel2BDE964E"
+          }
+        },
+        "RequestParameters": {
+          "method.request.path.pathParam": true,
+          "method.request.querystring.color": false
+        },
+        "ResourceId": {
+          "Ref": "ExampleAPIreceivepayloadpathParamD39EAFE4"
+        },
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        }
+      }
+    },
     "ExampleAPIApiExecutionRoleF249491B": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -400,6 +594,16 @@
               "Resource": {
                 "Fn::GetAtt": [
                   "ExampleAPIGetStatusDD96DC0A",
+                  "Arn"
+                ]
+              }
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ExampleAPIStorePayload1114E802",
                   "Arn"
                 ]
               }
@@ -497,11 +701,11 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "17229a1c144f3cdc29f7338482711a6dddee2d9010e1032395a874c8a74789a8.zip"
+          "S3Key": "7d33094bbf13d31a5e6930ccf43bb6d75f43c73b31fe8b217dbca1e8bf476343.zip"
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-07T20:49:08.173Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:39.170Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -552,16 +756,65 @@
         ]
       }
     },
+    "ExampleAPIStorePayloadServiceRoleDefaultPolicy79822C62": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ExampleServiceBucketFDFBB652",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ExampleServiceBucketFDFBB652",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "ExampleAPIStorePayloadServiceRoleDefaultPolicy79822C62",
+        "Roles": [
+          {
+            "Ref": "ExampleAPIStorePayloadServiceRoleB094D7CF"
+          }
+        ]
+      }
+    },
     "ExampleAPIStorePayload1114E802": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "157ca2282541d1b3a27b13661ae3f75e267e24c53161017f0279ff0a8c20e91f.zip"
+          "S3Key": "316a595db02a3e2a2d02e3250ac7004a86ec064313dd61f50345fb079d3cd333.zip"
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-09-07T20:49:09.767Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:43.271Z\"}",
+            "SERVICE_DATA_BUCKET_NAME": {
+              "Ref": "ExampleServiceBucketFDFBB652"
+            },
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -577,110 +830,9 @@
         "Timeout": 25
       },
       "DependsOn": [
+        "ExampleAPIStorePayloadServiceRoleDefaultPolicy79822C62",
         "ExampleAPIStorePayloadServiceRoleB094D7CF"
       ]
-    },
-    "PrivateAPIAuthorizerServiceRoleEBFD5560": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com"
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition"
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-              ]
-            ]
-          }
-        ]
-      }
-    },
-    "PrivateAPIAuthorizer2400616B": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "d4851594c211167082e004df0832206e28d72a4eec0a5bd7de423f707d47b569.zip"
-        },
-        "Environment": {
-          "Variables": {
-            "AUTH_VERIFIERS_JSON": "[]",
-            "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
-          }
-        },
-        "Handler": "index.handler",
-        "MemorySize": 256,
-        "Role": {
-          "Fn::GetAtt": [
-            "PrivateAPIAuthorizerServiceRoleEBFD5560",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 5
-      },
-      "DependsOn": [
-        "PrivateAPIAuthorizerServiceRoleEBFD5560"
-      ]
-    },
-    "PrivateAPIAuthorizerMyTestStackExampleAPIPrivateApiRequestAuthorizerEBBBC25APermissionsB6AD73EF": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "PrivateAPIAuthorizer2400616B",
-            "Arn"
-          ]
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition"
-              },
-              ":execute-api:eu-west-2:1234567890:",
-              {
-                "Ref": "ExampleAPI61CA833D"
-              },
-              "/authorizers/",
-              {
-                "Ref": "ExampleAPIPrivateApiRequestAuthorizerDB7A3947"
-              }
-            ]
-          ]
-        }
-      }
-    },
-    "ExampleServiceBucketFDFBB652": {
-      "Type": "AWS::S3::Bucket",
-      "Properties": {
-        "BucketName": "test-api-service-data-bucket",
-        "VersioningConfiguration": {
-          "Status": "Enabled"
-        }
-      },
-      "UpdateReplacePolicy": "Delete",
-      "DeletionPolicy": "Delete"
     },
     "ApiResponseModel7ED3C248": {
       "Type": "AWS::ApiGateway::Model",
@@ -712,6 +864,35 @@
             "statusCode",
             "type",
             "message"
+          ]
+        }
+      }
+    },
+    "ApiPayloadModel2BDE964E": {
+      "Type": "AWS::ApiGateway::Model",
+      "Properties": {
+        "ContentType": "application/json",
+        "Name": "ApiPayloadModel",
+        "RestApiId": {
+          "Ref": "ExampleAPI61CA833D"
+        },
+        "Schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Basic API Payload",
+          "type": "object",
+          "properties": {
+            "operationId": {
+              "type": "integer",
+              "description": "The HTTP status code of the response"
+            },
+            "payload": {
+              "type": "object",
+              "description": "The data payload of the request"
+            }
+          },
+          "required": [
+            "operationId",
+            "payload"
           ]
         }
       }

--- a/examples/src/tests/template.json
+++ b/examples/src/tests/template.json
@@ -705,7 +705,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:21.029Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:20:49.166Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -811,7 +811,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:24.556Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:20:52.823Z\"}",
             "SERVICE_DATA_BUCKET_NAME": {
               "Ref": "ExampleServiceBucketFDFBB652"
             },

--- a/examples/src/tests/template.json
+++ b/examples/src/tests/template.json
@@ -705,7 +705,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:39.170Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:21.029Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -811,7 +811,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:43.271Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:24.556Z\"}",
             "SERVICE_DATA_BUCKET_NAME": {
               "Ref": "ExampleServiceBucketFDFBB652"
             },

--- a/library/src/openapi/RestAPI.ts
+++ b/library/src/openapi/RestAPI.ts
@@ -260,6 +260,7 @@ export default class OpenAPIRestAPI<R> extends Construct {
   private createEndpointFromMetadata (endpointMetaData: OpenAPIRouteMetadata<R>, pathOverride?: string): OpenAPIEndpoint<OpenAPIFunction> {
     const supportedHttpMethods: { [key: string]: HttpMethod | undefined } = {
       GET: HttpMethod.GET,
+      PATCH: HttpMethod.PATCH,
       POST: HttpMethod.POST,
       PUT: HttpMethod.PUT,
       DELETE: HttpMethod.DELETE

--- a/library/src/openapi/RestAPI.ts
+++ b/library/src/openapi/RestAPI.ts
@@ -215,6 +215,11 @@ export default class OpenAPIRestAPI<R> extends Construct {
     return this.addEndpoint(endpoint)
   }
 
+  patch (path: string, lambda: OpenAPIFunction): OpenAPIRestAPI<R> {
+    const endpoint = new OpenAPIEndpoint(HttpMethod.PATCH, path, lambda)
+    return this.addEndpoint(endpoint)
+  }
+
   post (path: string, lambda: OpenAPIFunction): OpenAPIRestAPI<R> {
     const endpoint = new OpenAPIEndpoint(HttpMethod.POST, path, lambda)
     return this.addEndpoint(endpoint)

--- a/library/src/openapi/Routes.ts
+++ b/library/src/openapi/Routes.ts
@@ -48,6 +48,7 @@ export abstract class OpenAPIRouteMetadata<R> {
    *
    * Examples:
    *   return 'GET /status'
+   *   return 'PATCH /users/{userId}'
    *   return 'POST /users/{userId}/profile'
    *   return 'PUT  /profile/{profileId}'
    *   return 'DELETE /record/{recordId}'

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -438,7 +438,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:31.369Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:21:00.894Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -434,11 +434,11 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "18b246e63a4bf4eb166f64c2ba8c75b097cbaade4682c09076858812e0d28a01.zip"
+          "S3Key": "d5250ea240bd5ddabd357c1affea818102300957b52e05f7105541b301c3f8dc.zip"
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-10-16T16:35:56.490Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:44.965Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -438,7 +438,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:17:44.965Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:19:31.369Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },

--- a/library/src/tests/unit/restSignatures.test.ts
+++ b/library/src/tests/unit/restSignatures.test.ts
@@ -20,6 +20,10 @@ class StubGetEndpoint extends StubEndpoint {
   get operationId (): string { return 'getStub' }
 }
 
+class StubPatchEndpoint extends StubEndpoint {
+  get operationId (): string { return 'patchStub' }
+}
+
 class StubPutEndpoint extends StubEndpoint {
   get operationId (): string { return 'putStub' }
 }
@@ -57,6 +61,11 @@ describe('Rest Signatures', () => {
   it('should process GET paths', () => {
     const endpoint = new StubGetEndpoint()
     expect(() => api.addEndpoints({ 'GET /test': endpoint })).not.toThrow()
+  })
+
+  it('should process PATCH paths', () => {
+    const endpoint = new StubPatchEndpoint()
+    expect(() => api.addEndpoints({ 'PATCH /test': endpoint })).not.toThrow()
   })
 
   it('should process PUT paths', () => {
@@ -113,6 +122,7 @@ describe('Rest Signatures', () => {
       '| HTTP Method | Path | Operation ID |',
       '| --- | --- | --- |',
       '| GET | /test | getStub |',
+      '| PATCH | /test | patchStub |',
       '| PUT | /test | putStub |',
       '| POST | /test | postStub |',
       '| DELETE | /test | deleteStub |',

--- a/library/src/tests/unit/restSignatures.test.ts
+++ b/library/src/tests/unit/restSignatures.test.ts
@@ -76,7 +76,7 @@ describe('Rest Signatures', () => {
 
   it('should throw an error for unsupported HTTP methods', () => {
     const endpoint = new StubEndpoint()
-    expect(() => api.addEndpoints({ 'TEAPOT /test': endpoint })).toThrowError('Unsupported HTTP method: TEAPOT; supported keys are: GET, POST, PUT, DELETE')
+    expect(() => api.addEndpoints({ 'TEAPOT /test': endpoint })).toThrowError('Unsupported HTTP method: TEAPOT; supported keys are: GET, PATCH, POST, PUT, DELETE')
   })
 
   it('should throw an error when an invalid path signature is supplied', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connected-web/openapi-rest-api",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "workspaces": [
         "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An AWS-CDK library for building very cheap and extremely scalable OpenAPI documented APIs using AWS API Gateway, and AWS Lambda.",
   "main": "library/dist/src/PackageIndex.js",
   "scripts": {


### PR DESCRIPTION
Users getting this error:

>Unable to create endpoint for UpdateUser at PATCH /users/details; Error: Unsupported HTTP method: PATCH; supported keys are: GET, POST, PUT, DELETE}

- Add `HttpMethod.PATCH` to list of supported HTTP methods.
- Add `.patch()` helper to support legacy code.
- Update existing tests
- Write new tests