### PR TITLE
Make bundling more efficient; add test for default v1 stage

### DIFF
--- a/examples/src/tests/template.json
+++ b/examples/src/tests/template.json
@@ -705,7 +705,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:20:49.166Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2024-02-14T11:47:21.018Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },
@@ -811,7 +811,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:20:52.823Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2024-02-14T11:47:29.932Z\"}",
             "SERVICE_DATA_BUCKET_NAME": {
               "Ref": "ExampleServiceBucketFDFBB652"
             },

--- a/library/src/tests/library/api-stack.test.ts
+++ b/library/src/tests/library/api-stack.test.ts
@@ -45,4 +45,10 @@ describe('REST API using Harness as Test Bed', () => {
       OperationName: 'getStatus'
     })
   })
+
+  it('Creates a AWS ApiGateway with the v1 stage as default', () => {
+    template.hasResourceProperties('AWS::ApiGateway::Stage', {
+      StageName: 'v1'
+    })
+  })
 })

--- a/library/src/tests/library/harness/HarnessAPI.ts
+++ b/library/src/tests/library/harness/HarnessAPI.ts
@@ -4,7 +4,7 @@ import { Construct } from 'constructs'
 import { OpenAPIRestAPI, OpenAPIVerifiers, OpenAPIBasicModels } from '../../../PackageIndex'
 
 import { HarnessResources } from './Resources'
-import { HarnessEndpoint } from './endpoints/HarnessEndpoint'
+import { HarnessEndpoint } from './endpoints/HarnessEndpoint/metadata'
 
 export interface IdentityConfig {
   verifiers: OpenAPIVerifiers

--- a/library/src/tests/library/harness/endpoints/HarnessEndpoint/handler.ts
+++ b/library/src/tests/library/harness/endpoints/HarnessEndpoint/handler.ts
@@ -1,4 +1,7 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult
+} from 'aws-lambda/trigger/api-gateway-proxy'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -17,6 +20,7 @@ function lambdaResponse (statusCode: number, body: string = ''): APIGatewayProxy
   }
 }
 
+/* This handler is executed by AWS Lambda when the endpoint is invoked */
 export async function handler (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   const statusInfo = process.env.STATUS_INFO ?? JSON.stringify({ message: 'No STATUS_INFO found on env' })
   return lambdaResponse(200, statusInfo)

--- a/library/src/tests/library/harness/endpoints/HarnessEndpoint/metadata.ts
+++ b/library/src/tests/library/harness/endpoints/HarnessEndpoint/metadata.ts
@@ -1,20 +1,10 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyResult
-} from 'aws-lambda/trigger/api-gateway-proxy'
 
 import { Construct } from 'constructs'
 import { NodejsFunction, NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs'
 import { MethodResponse, IModel } from 'aws-cdk-lib/aws-apigateway'
 
-import { OpenAPIRouteMetadata, OpenAPIHelpers, OpenAPIEnums, OpenAPIBasicModels } from '../../../../PackageIndex'
-import { HarnessResources } from '../Resources'
-
-/* This handler is executed by AWS Lambda when the endpoint is invoked */
-export async function handler (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  const statusInfo = process.env.STATUS_INFO ?? JSON.stringify({ message: 'No STATUS_INFO found on env' })
-  return OpenAPIHelpers.lambdaResponse(OpenAPIEnums.httpStatusCodes.success, statusInfo)
-}
+import { OpenAPIRouteMetadata, OpenAPIBasicModels } from '../../../../../PackageIndex'
+import { HarnessResources } from '../../Resources'
 
 /* This section is for route metadata used by CDK to create the stack that will host your endpoint */
 export class HarnessEndpoint extends OpenAPIRouteMetadata<HarnessResources> {

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -434,11 +434,11 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "d5250ea240bd5ddabd357c1affea818102300957b52e05f7105541b301c3f8dc.zip"
+          "S3Key": "80ffdd2e318d1dc257785c32243057b6126bf59b9c72d99eb6e08dc10763f2d1.zip"
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2023-12-05T12:21:00.894Z\"}",
+            "STATUS_INFO": "{\"deploymentTime\":\"2024-02-14T11:57:26.146Z\"}",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },


### PR DESCRIPTION
## In this PR
- Reduce bundled file size for test and stub handlers from `~18Mb` to `~800b`.
- Expand test coverage to include `v1` stage default