### PR TITLE
Use nodeModules instead of bundling external

### DIFF
--- a/library/src/openapi/Function.ts
+++ b/library/src/openapi/Function.ts
@@ -70,7 +70,7 @@ export default class OpenAPIFunction {
       entry: routeEntryPoint,
       bundling: {
         minify: true,
-        nodeModules: ['@aws-sdk/*', 'aws-sdk']
+        nodeModules: ['aws-sdk']
       }
     }
 

--- a/library/src/openapi/Function.ts
+++ b/library/src/openapi/Function.ts
@@ -70,7 +70,7 @@ export default class OpenAPIFunction {
       entry: routeEntryPoint,
       bundling: {
         minify: true,
-        externalModules: ['@aws-sdk/*', 'aws-sdk']
+        nodeModules: ['@aws-sdk/*', 'aws-sdk']
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connected-web/openapi-rest-api",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "workspaces": [
         "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An AWS-CDK library for building very cheap and extremely scalable OpenAPI documented APIs using AWS API Gateway, and AWS Lambda.",
   "main": "library/dist/src/PackageIndex.js",
   "scripts": {


### PR DESCRIPTION
## In this PR

- Update `Function.ts` to use `nodeModules` instead of `externalModules` to bundle
- Avoid common case where `aws-sdk` not available with newer versions of NodeJS lambdas

## Checklist

- [x] Code quality follows existing standards
- [x] Additional tests have been added to cover new functionality
- [x] CI Tests pass on pipeline
- [x] Documentation has been updated