### PR TITLE
Create AuthorizationLogger to track authorisation events cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The authorizer supports multiple Cognito User Pool clients to allow for differen
 
 #### Example HeaderAuthorizer
 
+Header-based authorization can be used to validate requests based on custom headers. This is useful for machine-to-machine communication, or for simple API key validation. The `HeaderAuthorizer` configuration supports the following parameters:
+
 ```json
 "HeaderAuthorizer": {
   "requiredHeadersWithAllowedValues": {
@@ -70,6 +72,9 @@ The authorizer supports multiple Cognito User Pool clients to allow for differen
 }
 ```
 
+Note when using `HeaderAuthorizer`, the `resultsCacheTtl` is set to `0` seconds to disable caching, ensuring each request is validated against the specified headers.
+
+#### Other OpenAPIRestAPI Features
 
 The `OpenAPIRestAPI<*>` interface also supports the following methods:
 

--- a/library/src/openapi/HeaderAuthorizer.ts
+++ b/library/src/openapi/HeaderAuthorizer.ts
@@ -2,6 +2,149 @@ import { APIGatewayAuthorizerResult, APIGatewayRequestAuthorizerEvent, APIGatewa
 import { OpenAPIHeaderAuthorizerProps } from './RestAPI'
 import { OpenAPIAuthorizerContext } from './AWSCognitoAuthorizer'
 
+// Authorization logging interfaces
+interface AuthorizationLogEvent {
+  type: 'header-check' | 'regex-check' | 'disallowed-check' | 'policy-decision'
+  checkType: string
+  header?: string
+  expected?: string | string[]
+  actual?: string
+  result: 'pass' | 'fail'
+  message: string
+}
+
+interface HeaderCriteriaResult {
+  checkType: string
+  result: 'pass' | 'fail'
+  details: string
+  matchedHeaders?: Record<string, string>
+  failedHeaders?: Record<string, { expected: string | string[], actual: string }>
+}
+
+interface AuthorizationSummary {
+  suppliedHeaders: Record<string, string>
+  criteriaResults: HeaderCriteriaResult[]
+  finalDecision: 'Allow' | 'Deny'
+  principalId: string
+  reason: string
+  timestamp: string
+}
+
+// Authorization logger class
+class AuthorizationLogger {
+  private readonly events: AuthorizationLogEvent[] = []
+  private readonly suppliedHeaders: Record<string, string> = {}
+
+  constructor (headers: APIGatewayRequestAuthorizerEventHeaders) {
+    // Convert headers to lowercase for consistent handling
+    this.suppliedHeaders = toLowerKeys(headers)
+  }
+
+  logHeaderCheck (checkType: string, header: string, expected: string | string[], actual: string, result: 'pass' | 'fail'): void {
+    this.events.push({
+      type: 'header-check',
+      checkType,
+      header,
+      expected,
+      actual,
+      result,
+      message: `Header '${header}': expected ${JSON.stringify(expected)}, got '${actual}' - ${result}`
+    })
+  }
+
+  logRegexCheck (checkType: string, header: string, pattern: string, actual: string, result: 'pass' | 'fail'): void {
+    this.events.push({
+      type: 'regex-check',
+      checkType,
+      header,
+      expected: pattern,
+      actual,
+      result,
+      message: `Header '${header}': pattern /${pattern}/ ${result === 'pass' ? 'matched' : 'did not match'} '${actual}'`
+    })
+  }
+
+  logDisallowedCheck (checkType: string, header: string, result: 'pass' | 'fail', reason?: string): void {
+    this.events.push({
+      type: 'disallowed-check',
+      checkType,
+      header,
+      result,
+      message: reason ?? `Header '${header}' disallowed check: ${result}`
+    })
+  }
+
+  logPolicyDecision (result: 'pass' | 'fail', reason: string): void {
+    this.events.push({
+      type: 'policy-decision',
+      checkType: 'final-decision',
+      result,
+      message: reason
+    })
+  }
+
+  generateSummary (finalDecision: 'Allow' | 'Deny', principalId: string, reason: string): AuthorizationSummary {
+    const criteriaResults: HeaderCriteriaResult[] = []
+
+    // Group events by check type
+    const eventsByCheckType = this.events.reduce<Record<string, AuthorizationLogEvent[]>>((acc, event) => {
+      const key = event.checkType
+      if (acc[key] === undefined) acc[key] = []
+      acc[key].push(event)
+      return acc
+    }, {})
+
+    // Create criteria results for each check type
+    for (const [checkType, events] of Object.entries(eventsByCheckType)) {
+      if (checkType === 'final-decision') continue
+
+      const failedEvents = events.filter(e => e.result === 'fail')
+      const passedEvents = events.filter(e => e.result === 'pass')
+
+      const matchedHeaders: Record<string, string> = {}
+      const failedHeaders: Record<string, { expected: string | string[], actual: string }> = {}
+
+      passedEvents.forEach(event => {
+        if (event.header != null && event.header !== '' && event.actual !== undefined) {
+          matchedHeaders[event.header] = event.actual
+        }
+      })
+
+      failedEvents.forEach(event => {
+        if (event.header != null && event.header !== '' && event.expected !== undefined && event.actual !== undefined) {
+          failedHeaders[event.header] = {
+            expected: event.expected,
+            actual: event.actual
+          }
+        }
+      })
+
+      criteriaResults.push({
+        checkType,
+        result: failedEvents.length > 0 ? 'fail' : 'pass',
+        details: failedEvents.length > 0
+          ? `${failedEvents.length} check(s) failed: ${failedEvents.map(e => e.message).join('; ')}`
+          : `All ${passedEvents.length} check(s) passed`,
+        matchedHeaders: Object.keys(matchedHeaders).length > 0 ? matchedHeaders : undefined,
+        failedHeaders: Object.keys(failedHeaders).length > 0 ? failedHeaders : undefined
+      })
+    }
+
+    return {
+      suppliedHeaders: this.suppliedHeaders,
+      criteriaResults,
+      finalDecision,
+      principalId,
+      reason,
+      timestamp: new Date().toISOString()
+    }
+  }
+
+  logSummary (summary: AuthorizationSummary): void {
+    console.log('Authorization Summary:', JSON.stringify(summary, null, 2))
+  }
+}
+
 const {
   REQUIRED_HEADERS_WITH_ALLOWED_VALUES_JSON,
   REQUIRED_HEADERS_REGEX_VALUES_JSON,
@@ -30,15 +173,14 @@ const headerAuthorizerSettings: OpenAPIHeaderAuthorizerProps = {
 
 export async function handler (event: APIGatewayRequestAuthorizerEvent): Promise<APIGatewayAuthorizerResult> {
   const availableHeaders = event?.headers ?? {}
-  console.log('Authorizing using Available Headers')
   return await checkHeadersForPolicyMatch(availableHeaders, headerAuthorizerSettings)
 }
 
 export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRequestAuthorizerEventHeaders, headerAuthorizerSettings: OpenAPIHeaderAuthorizerProps): Promise<APIGatewayAuthorizerResult> {
+  const logger = new AuthorizationLogger(availableHeaders)
   const policies: APIGatewayAuthorizerResult[] = []
 
   if (headerAuthorizerSettings.requiredHeadersWithAllowedValues !== undefined) {
-    console.log('Checking requiredHeadersWithAllowedValues')
     const requiredHeadersWithAllowedValues = headerAuthorizerSettings.requiredHeadersWithAllowedValues
     let allMatch = true
     for (const header in requiredHeadersWithAllowedValues) {
@@ -46,12 +188,13 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
       const headerValue = availableHeaders[header] ?? availableHeaders[header.toLowerCase()] ?? ''
       if (!allowedValues.includes(headerValue)) {
         allMatch = false
-        console.log(`Header ${header} with value ${headerValue} does not match allowed values`, { allowedValues })
+        logger.logHeaderCheck('requiredHeadersWithAllowedValues', header, allowedValues, headerValue, 'fail')
         break
+      } else {
+        logger.logHeaderCheck('requiredHeadersWithAllowedValues', header, allowedValues, headerValue, 'pass')
       }
     }
     if (allMatch) {
-      console.log('All requiredHeadersWithAllowedValues matched')
       policies.push(buildPolicy('Allow', 'required-headers-with-allowed-values', { method: 'requiredHeadersWithAllowedValues' }))
     } else {
       policies.push(buildPolicy('Deny', 'required-headers-with-allowed-values', { authorizerError: 'Required headers with allowed values did not match' }))
@@ -59,7 +202,6 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
   }
 
   if (headerAuthorizerSettings.requiredHeadersRegexValues !== undefined) {
-    console.log('Checking requiredHeadersRegexValues')
     const requiredHeadersRegexValues = headerAuthorizerSettings.requiredHeadersRegexValues
     let allMatch = true
     for (const header in requiredHeadersRegexValues) {
@@ -68,12 +210,13 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
       const headerValue = availableHeaders[header] ?? availableHeaders[header.toLowerCase()] ?? ''
       if (!regex.test(headerValue)) {
         allMatch = false
-        console.log(`Header ${header} with value ${headerValue} does not match regex`, { regex: regexString })
+        logger.logRegexCheck('requiredHeadersRegexValues', header, regexString, headerValue, 'fail')
         break
+      } else {
+        logger.logRegexCheck('requiredHeadersRegexValues', header, regexString, headerValue, 'pass')
       }
     }
     if (allMatch) {
-      console.log('All requiredHeadersRegexValues matched')
       policies.push(buildPolicy('Allow', 'required-headers-regex-values', { method: 'requiredHeadersRegexValues' }))
     } else {
       policies.push(buildPolicy('Deny', 'required-headers-regex-values', { authorizerError: 'Required headers regex values did not match' }))
@@ -81,27 +224,26 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
   }
 
   if (headerAuthorizerSettings.disallowedHeaders !== undefined) {
-    console.log('Checking disallowedHeaders')
     const disallowedHeaders = headerAuthorizerSettings.disallowedHeaders
     let anyMatch = false
     for (const header of disallowedHeaders) {
       const headerValue = availableHeaders[header] ?? availableHeaders[header.toLowerCase()] ?? ''
       if (headerValue !== '') {
         anyMatch = true
-        console.log(`Disallowed header ${header} is present with value`, { headerValue })
+        logger.logDisallowedCheck('disallowedHeaders', header, 'fail', `Disallowed header '${header}' is present with value '${headerValue}'`)
         break
+      } else {
+        logger.logDisallowedCheck('disallowedHeaders', header, 'pass', `Disallowed header '${header}' is not present`)
       }
     }
     if (anyMatch) {
       policies.push(buildPolicy('Deny', 'disallowed-headers', { authorizerError: 'Disallowed headers were present' }))
     } else {
-      console.log('No disallowedHeaders were present')
       policies.push(buildPolicy('Allow', 'disallowed-headers', { method: 'disallowedHeaders' }))
     }
   }
 
   if (headerAuthorizerSettings.disallowedHeaderRegexes !== undefined) {
-    console.log('Checking disallowedHeaderRegexes')
     const disallowedHeaderRegexes = headerAuthorizerSettings.disallowedHeaderRegexes
     let anyMatch = false
     disallowedHeaderRegexes.forEach((regexString) => {
@@ -109,7 +251,7 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
       for (const header in availableHeaders) {
         if (regex.test(header)) {
           anyMatch = true
-          console.log(`Header ${header} matches disallowed regex`, { regex: regexString })
+          logger.logDisallowedCheck('disallowedHeaderRegexes', header, 'fail', `Header '${header}' matches disallowed regex /${regexString}/`)
           break
         }
       }
@@ -117,19 +259,46 @@ export async function checkHeadersForPolicyMatch (availableHeaders: APIGatewayRe
     if (anyMatch) {
       policies.push(buildPolicy('Deny', 'disallowed-header-regexes', { authorizerError: 'Disallowed header regexes matched' }))
     } else {
-      console.log('No disallowedHeaderRegexes matched')
+      // Log successful checks for headers that didn't match any disallowed regex
+      Object.keys(availableHeaders).forEach(header => {
+        logger.logDisallowedCheck('disallowedHeaderRegexes', header, 'pass', `Header '${header}' does not match any disallowed regex patterns`)
+      })
       policies.push(buildPolicy('Allow', 'disallowed-header-regexes', { method: 'disallowedHeaderRegexes' }))
     }
   }
 
+  // Determine final policy and generate summary
+  let finalPolicy: APIGatewayAuthorizerResult
+  let finalDecision: 'Allow' | 'Deny'
+  let reason: string
+
   // Prefer Deny if present
   const denyPolicy = policies.find(policy => policy.policyDocument.Statement[0].Effect === 'Deny')
-  if (denyPolicy != null) return denyPolicy
+  if (denyPolicy != null) {
+    finalPolicy = denyPolicy
+    finalDecision = 'Deny'
+    reason = denyPolicy.context?.authorizerError ?? 'Access denied by policy'
+    logger.logPolicyDecision('fail', reason)
+  } else {
+    const allowPolicy = policies.find(policy => policy.policyDocument.Statement[0].Effect === 'Allow')
+    if (allowPolicy != null) {
+      finalPolicy = allowPolicy
+      finalDecision = 'Allow'
+      reason = 'Access granted - all criteria passed'
+      logger.logPolicyDecision('pass', reason)
+    } else {
+      finalPolicy = buildPolicy('Deny', 'no-verifiers-configured', { authorizerError: 'No verifiers configured' })
+      finalDecision = 'Deny'
+      reason = 'No verifiers configured'
+      logger.logPolicyDecision('fail', reason)
+    }
+  }
 
-  const allowPolicy = policies.find(policy => policy.policyDocument.Statement[0].Effect === 'Allow')
-  if (allowPolicy != null) return allowPolicy
+  // Generate and log the summary
+  const summary = logger.generateSummary(finalDecision, finalPolicy.principalId, reason)
+  logger.logSummary(summary)
 
-  return buildPolicy('Deny', 'no-verifiers-configured', { authorizerError: 'No verifiers configured' })
+  return finalPolicy
 }
 
 function buildPolicy (allowOrDeny: 'Allow' | 'Deny', principalId: string, context: OpenAPIAuthorizerContext): APIGatewayAuthorizerResult {

--- a/library/src/openapi/RestAPI.ts
+++ b/library/src/openapi/RestAPI.ts
@@ -232,7 +232,8 @@ export default class OpenAPIRestAPI<R> extends Construct {
 
       defaultMethodOptions.authorizer = new RequestAuthorizer(this, 'PrivateApiRequestAuthorizer', {
         handler: authLambda,
-        identitySources: expectedHeaders.map(headerKey => IdentitySource.header(headerKey))
+        identitySources: expectedHeaders.map(headerKey => IdentitySource.header(headerKey)),
+        resultsCacheTtl: Duration.seconds(0) // Disable caching for header-based authorizer
       })
     }
 

--- a/library/src/tests/template-with-custom-header-authorizer.json
+++ b/library/src/tests/template-with-custom-header-authorizer.json
@@ -505,7 +505,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T15:28:46.551Z\"}"
+            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T21:19:41.581Z\"}"
           }
         },
         "Handler": "index.handler",
@@ -560,7 +560,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-1234567890-eu-west-2",
-          "S3Key": "513ec0f6daee6b54312cff6a85d99197b5ab13a9a41d5cdbd9e0f029ef457bf8.zip"
+          "S3Key": "ac75ab5f6a4fa1394c3a1538dc4b0276521c0c26d8588c46074495d8419bfd40.zip"
         },
         "Environment": {
           "Variables": {

--- a/library/src/tests/template-with-custom-props.json
+++ b/library/src/tests/template-with-custom-props.json
@@ -441,7 +441,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T15:28:57.219Z\"}"
+            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T21:19:50.660Z\"}"
           }
         },
         "Handler": "index.handler",

--- a/library/src/tests/template.json
+++ b/library/src/tests/template.json
@@ -441,7 +441,7 @@
         },
         "Environment": {
           "Variables": {
-            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T15:28:17.787Z\"}"
+            "STATUS_INFO": "{\"deploymentTime\":\"2025-09-23T21:19:13.073Z\"}"
           }
         },
         "Handler": "index.handler",

--- a/library/src/tests/unit/authorizationLogging.test.ts
+++ b/library/src/tests/unit/authorizationLogging.test.ts
@@ -1,0 +1,100 @@
+import { expect, describe, it, jest } from '@jest/globals'
+import { checkHeadersForPolicyMatch } from '../../openapi/HeaderAuthorizer'
+
+describe('Authorization Logging', () => {
+  let consoleSpy: jest.SpiedFunction<typeof console.log>
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+  })
+
+  it('should log a single authorization summary instead of multiple console.log calls', async () => {
+    const headerAuthorizerSettings = {
+      requiredHeadersWithAllowedValues: {
+        'x-api-key': ['1234567890', '0987654321'],
+        'x-client-id': ['client-1', 'client-2']
+      },
+      disallowedHeaders: ['x-forbidden']
+    }
+
+    const availableHeaders = {
+      'x-api-key': '1234567890',
+      'x-client-id': 'client-2',
+      'x-custom': 'value'
+    }
+
+    const result = await checkHeadersForPolicyMatch(availableHeaders, headerAuthorizerSettings)
+
+    // Should only log once for the authorization summary
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+
+    // The single log should be an Authorization Summary
+    const logCall = consoleSpy.mock.calls[0]
+    expect(logCall[0]).toBe('Authorization Summary:')
+
+    // Parse the JSON summary
+    const summary = JSON.parse(logCall[1])
+
+    // Verify summary structure
+    expect(summary).toHaveProperty('suppliedHeaders')
+    expect(summary).toHaveProperty('criteriaResults')
+    expect(summary).toHaveProperty('finalDecision')
+    expect(summary).toHaveProperty('principalId')
+    expect(summary).toHaveProperty('reason')
+    expect(summary).toHaveProperty('timestamp')
+
+    // Verify supplied headers are captured
+    expect(summary.suppliedHeaders).toEqual({
+      'x-api-key': '1234567890',
+      'x-client-id': 'client-2',
+      'x-custom': 'value'
+    })
+
+    // Verify criteria results are present
+    expect(summary.criteriaResults).toHaveLength(2)
+    expect(summary.criteriaResults[0].checkType).toBe('requiredHeadersWithAllowedValues')
+    expect(summary.criteriaResults[0].result).toBe('pass')
+    expect(summary.criteriaResults[1].checkType).toBe('disallowedHeaders')
+    expect(summary.criteriaResults[1].result).toBe('pass')
+
+    // Verify final decision
+    expect(summary.finalDecision).toBe('Allow')
+    expect(result.policyDocument.Statement[0].Effect).toBe('Allow')
+  })
+
+  it('should provide detailed failure information in the summary', async () => {
+    const headerAuthorizerSettings = {
+      requiredHeadersWithAllowedValues: {
+        'x-api-key': ['valid-key']
+      },
+      requiredHeadersRegexValues: {
+        'x-session-id': '^session-[0-9]{6}$'
+      }
+    }
+
+    const availableHeaders = {
+      'x-api-key': 'invalid-key',
+      'x-session-id': 'bad-session-123456'
+    }
+
+    await checkHeadersForPolicyMatch(availableHeaders, headerAuthorizerSettings)
+
+    const logCall = consoleSpy.mock.calls[0]
+    const summary = JSON.parse(logCall[1])
+
+    // Should have failed criteria
+    expect(summary.finalDecision).toBe('Deny')
+    expect(summary.criteriaResults[0].result).toBe('fail')
+
+    // Should have detailed failure information
+    expect(summary.criteriaResults[0].failedHeaders).toHaveProperty('x-api-key')
+    expect(summary.criteriaResults[0].failedHeaders['x-api-key']).toEqual({
+      expected: ['valid-key'],
+      actual: 'invalid-key'
+    })
+  })
+})


### PR DESCRIPTION
## In this PR

- Change logging behaviour in HeaderAuthorizer
- Set `resultsCacheTtl` to 0 to disable caching for the HeaderAuthorizer 

## Checklist

- [x] Code quality follows existing standards
- [x] Additional tests have been added to cover new functionality
- [x] CI Tests pass on pipeline
- [x] Documentation has been updated