### PR TITLE
Deduplicate GitHub step summaries and add report output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,15 @@ If this environment variable is set to `true`, the CDK stack will create a CNAME
 
 ### OPENAPI_REST_API_REPORT_SUMMARY
 
-If this environment variable is set to `true`, the CDK stack will report the API Gateway URL and the OpenAPI specification URL. This is useful if you want to quickly access the API Gateway URL and the OpenAPI specification URL after deployment. It also summarises a table of endpoints, which is useful documentation for the API that you can copy and paste out of the `GITHUB_STEP_SUMMARY`.
+If this environment variable is set to `true`, the CDK stack will generate a markdown deployment summary containing endpoint documentation.
+
+### OPENAPI_REST_API_REPORT_OUTPUT_PATH
+
+If this environment variable is set, the generated markdown deployment summary will be written to this path. This is the recommended way to consume the summary from CI/CD flows.
+
+### OPENAPI_REST_API_REPORT_DISABLE_GITHUB_STEP_SUMMARY
+
+If this environment variable is set to `true`, `openapi-rest-api` will not append to `GITHUB_STEP_SUMMARY`. This lets consumers opt-in to writing job summaries themselves using the document from `OPENAPI_REST_API_REPORT_OUTPUT_PATH`.
 
 For example:
 
@@ -496,6 +504,9 @@ For example:
         env:
           CREATE_CNAME_RECORD: true
           OPENAPI_REST_API_REPORT_SUMMARY: true
+          OPENAPI_REST_API_REPORT_OUTPUT_PATH: deployment-summary.md
+      - name: Publish deployment summary (optional)
+        run: cat deployment-summary.md >> "$GITHUB_STEP_SUMMARY"
 ```
 
 ## Contributions and Questions

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-rest-api-example",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "scripts": {
     "test": "eslint . --ext .ts && npm run test:example",
     "test:example": "vitest run --dir src/tests",

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-rest-api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "scripts": {
     "build": "npx tsc -p tsconfig.build.json",
     "test": "eslint . --ext .ts && vitest run",

--- a/library/src/openapi/RestAPI.ts
+++ b/library/src/openapi/RestAPI.ts
@@ -472,20 +472,63 @@ export default class OpenAPIRestAPI<R> extends Construct {
     return summary.join('\n')
   }
 
+  private shouldReportSummary (): boolean {
+    return process.env.OPENAPI_REST_API_REPORT_SUMMARY !== undefined
+  }
+
+  private shouldWriteGithubStepSummary (): boolean {
+    return process.env.GITHUB_STEP_SUMMARY !== undefined &&
+      process.env.OPENAPI_REST_API_REPORT_DISABLE_GITHUB_STEP_SUMMARY === undefined
+  }
+
+  private writeReportDocument (markdownSummary: string): void {
+    if (process.env.OPENAPI_REST_API_REPORT_OUTPUT_PATH === undefined) {
+      return
+    }
+
+    fs.writeFileSync(process.env.OPENAPI_REST_API_REPORT_OUTPUT_PATH, `${markdownSummary}\n`)
+  }
+
+  private appendUniqueContent (filePath: string, content: string): boolean {
+    const normalizedContent = content.trim()
+    let existingContent = ''
+
+    try {
+      existingContent = fs.readFileSync(filePath, 'utf8')
+    } catch (ex) {
+      const error = ex as NodeJS.ErrnoException
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
+    }
+
+    if (existingContent.includes(normalizedContent)) {
+      return false
+    }
+
+    const hasExistingContent = existingContent.trim().length > 0
+    const output = hasExistingContent ? `\n\n${normalizedContent}\n` : `${normalizedContent}\n`
+    fs.writeFileSync(filePath, output, { flag: 'a' })
+    return true
+  }
+
   report (): void {
     console.log('OpenAPIRestAPI Routes:', Object.values(this.routeMap).map(route => route.path))
 
-    // Update step summary
-    if (process.env.GITHUB_STEP_SUMMARY !== undefined && process.env.OPENAPI_REST_API_REPORT_SUMMARY !== undefined) {
+    if (this.shouldReportSummary()) {
       try {
         const markdownSummary = this.generateReportMarkdown()
+        this.writeReportDocument(markdownSummary)
 
-        console.log('Markdown for Github job summary:\n\n', markdownSummary)
-
-        fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, markdownSummary, { flag: 'a' })
+        if (this.shouldWriteGithubStepSummary() && process.env.GITHUB_STEP_SUMMARY !== undefined) {
+          const wasWritten = this.appendUniqueContent(process.env.GITHUB_STEP_SUMMARY, markdownSummary)
+          if (!wasWritten) {
+            console.log('Skipped duplicate OpenAPI report for Github step summary.')
+          }
+        }
       } catch (ex) {
         const error = ex as Error
-        console.error('Unable to produce Github step summary:', error.message)
+        console.error('Unable to produce OpenAPI report summary:', error.message)
       }
     }
   }

--- a/library/src/tests/unit/reportSummary.test.ts
+++ b/library/src/tests/unit/reportSummary.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, afterEach } from 'vitest'
+import { expect } from 'chai'
+import * as cdk from 'aws-cdk-lib'
+import sinon from 'sinon'
+import fs from 'fs'
+
+import { OpenAPIRestAPI } from '../../PackageIndex'
+
+const ENV_KEYS = [
+  'CREATE_CNAME_RECORD',
+  'OPENAPI_REST_API_REPORT_SUMMARY',
+  'OPENAPI_REST_API_REPORT_OUTPUT_PATH',
+  'OPENAPI_REST_API_REPORT_DISABLE_GITHUB_STEP_SUMMARY',
+  'GITHUB_STEP_SUMMARY'
+] as const
+
+describe('OpenAPI report summary output', () => {
+  afterEach(() => {
+    sinon.restore()
+    for (const key of ENV_KEYS) {
+      delete process.env[key]
+    }
+  })
+
+  it('writes a report document when OPENAPI_REST_API_REPORT_OUTPUT_PATH is set', () => {
+    process.env.CREATE_CNAME_RECORD = 'false'
+    process.env.OPENAPI_REST_API_REPORT_SUMMARY = 'true'
+    process.env.OPENAPI_REST_API_REPORT_OUTPUT_PATH = '/tmp/openapi-summary.md'
+
+    const writeFileSyncStub = sinon.stub(fs, 'writeFileSync')
+    const app = new cdk.App()
+    const stack = new cdk.Stack(app, 'ReportOutputPathStack', {
+      env: { account: '123456789012', region: 'us-east-1' }
+    })
+
+    const api = new OpenAPIRestAPI(stack, 'TestApi', {
+      Description: 'Summary report test API',
+      SubDomain: 'test-api',
+      HostedZoneDomain: 'example.com',
+      Verifiers: []
+    }, {})
+
+    api.report()
+
+    expect(writeFileSyncStub.calledWithMatch('/tmp/openapi-summary.md', sinon.match.string)).to.equal(true)
+  })
+
+  it('deduplicates github step summary writes when report is emitted multiple times', () => {
+    process.env.CREATE_CNAME_RECORD = 'false'
+    process.env.OPENAPI_REST_API_REPORT_SUMMARY = 'true'
+    process.env.GITHUB_STEP_SUMMARY = '/tmp/github-step-summary.md'
+
+    let summaryFileContent = ''
+
+    sinon.stub(fs, 'readFileSync').callsFake((path: fs.PathOrFileDescriptor, options?: any) => {
+      if (path === '/tmp/github-step-summary.md') {
+        return summaryFileContent
+      }
+      return ''
+    })
+
+    const writeFileSyncStub = sinon.stub(fs, 'writeFileSync').callsFake((path: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView) => {
+      if (path === '/tmp/github-step-summary.md') {
+        summaryFileContent += data.toString()
+      }
+    })
+
+    const app = new cdk.App()
+    const stack = new cdk.Stack(app, 'ReportSummaryDedupeStack', {
+      env: { account: '123456789012', region: 'us-east-1' }
+    })
+
+    const api = new OpenAPIRestAPI(stack, 'TestApi', {
+      Description: 'Summary report test API',
+      SubDomain: 'test-api',
+      HostedZoneDomain: 'example.com',
+      Verifiers: []
+    }, {})
+
+    api.report()
+    api.report()
+
+    expect(writeFileSyncStub.calledOnce).to.equal(true)
+    expect(summaryFileContent).to.contain('# TestApi')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "An AWS-CDK library for building very cheap and extremely scalable OpenAPI documented APIs using AWS API Gateway, and AWS Lambda.",
   "main": "library/dist/PackageIndex.js",
   "types": "library/dist/PackageIndex.d.ts",


### PR DESCRIPTION
### Motivation

- Prevent duplicate markdown summaries being appended to `GITHUB_STEP_SUMMARY` when `report()` is invoked multiple times during a deployment run. 
- Provide a CI-friendly alternative where the generated markdown summary can be written to a standalone file for consumers to publish as they prefer.

### Description

- Add `shouldReportSummary()`, `shouldWriteGithubStepSummary()`, `writeReportDocument()` and `appendUniqueContent()` helpers and refactor `report()` to deduplicate writes and optionally write a separate document in `library/src/openapi/RestAPI.ts`.
- Preserve existing GitHub step summary behavior by default but skip writing duplicate content and allow it to be disabled via `OPENAPI_REST_API_REPORT_DISABLE_GITHUB_STEP_SUMMARY`.
- Add `OPENAPI_REST_API_REPORT_OUTPUT_PATH` support so the generated markdown can be written to a file for CI/CD consumers.
- Update `README.md` to document the new environment variables and add `library/src/tests/unit/reportSummary.test.ts` covering output-file writes and deduplication behavior.

### Testing

- Ran unit tests with `npm -w library run test:unit` and all tests passed (38 tests across unit suites).
- Ran linter with `npm -w library run lint` and it succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40e79085c83319cdfe207b9838915)