### PR TITLE
Publish releases to GitHub Packages as well as npmjs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,11 +41,15 @@ jobs:
 
       - name: Verify tag matches version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=$(node -p "require('semver').clean(require('./package.json').version)")
           TAG=${{ steps.release_tag.outputs.tag }}
-          NORMALIZED_TAG=${TAG#v}
-          if [ "$VERSION" != "$NORMALIZED_TAG" ]; then
-            echo "Error: Release tag '$TAG' (normalized: '$NORMALIZED_TAG') does not match package version '$VERSION'"
+          TAG_VERSION=$(node -p "require('semver').clean(process.argv[1])" "$TAG")
+          if [ -z "$VERSION" ] || [ -z "$TAG_VERSION" ]; then
+            echo "Error: Invalid semver value (tag: '$TAG', package version: '$VERSION')"
+            exit 1
+          fi
+          if [ "$VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: Release tag '$TAG' (version: '$TAG_VERSION') does not match package version '$VERSION'"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,15 +41,10 @@ jobs:
 
       - name: Verify tag matches version
         run: |
-          VERSION=$(node -p "require('semver').clean(require('./package.json').version)")
+          VERSION=$(node -p "require('./package.json').version")
           TAG=${{ steps.release_tag.outputs.tag }}
-          TAG_VERSION=$(node -p "require('semver').clean(process.argv[1])" "$TAG")
-          if [ -z "$VERSION" ] || [ -z "$TAG_VERSION" ]; then
-            echo "Error: Invalid semver value (tag: '$TAG', package version: '$VERSION')"
-            exit 1
-          fi
-          if [ "$VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: Release tag '$TAG' (version: '$TAG_VERSION') does not match package version '$VERSION'"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "Error: Release tag '$TAG' does not match package version '$VERSION'"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-  
+
       - name: Use Node JS LTS
         uses: actions/setup-node@v6
         with:
@@ -29,11 +30,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build TypeScript
         run: npm run build
         working-directory: ./library
-      
+
       - name: Get Release Tag
         id: release_tag
         run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
@@ -46,6 +47,18 @@ jobs:
             echo "Error: Release tag '$TAG' does not match package version '$VERSION'"
             exit 1
           fi
-          
+
       - name: Publish to npm (trusted publishing)
         run: npm publish --provenance --access public
+
+      - name: Configure npm for GitHub Packages
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@connected-web'
+
+      - name: Publish to GitHub Packages
+        run: npm publish --registry https://npm.pkg.github.com --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,9 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG=${{ steps.release_tag.outputs.tag }}
-          if [ "$VERSION" != "$TAG" ]; then
-            echo "Error: Release tag '$TAG' does not match package version '$VERSION'"
+          NORMALIZED_TAG=${TAG#v}
+          if [ "$VERSION" != "$NORMALIZED_TAG" ]; then
+            echo "Error: Release tag '$TAG' (normalized: '$NORMALIZED_TAG') does not match package version '$VERSION'"
             exit 1
           fi
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-rest-api-example",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "scripts": {
     "test": "eslint . --ext .ts && npm run test:example",
     "test:example": "vitest run --dir src/tests",

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-rest-api",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "scripts": {
     "build": "npx tsc -p tsconfig.build.json",
     "test": "eslint . --ext .ts && vitest run",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connected-web/openapi-rest-api",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "ISC",
       "workspaces": [
         "library",
@@ -22,7 +22,7 @@
     },
     "examples": {
       "name": "openapi-rest-api-example",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.984.0",
@@ -59,7 +59,7 @@
     },
     "library": {
       "name": "openapi-rest-api",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.984.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-web/openapi-rest-api",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "An AWS-CDK library for building very cheap and extremely scalable OpenAPI documented APIs using AWS API Gateway, and AWS Lambda.",
   "main": "library/dist/PackageIndex.js",
   "types": "library/dist/PackageIndex.d.ts",

--- a/scripts/premergeVersionCheck.ts
+++ b/scripts/premergeVersionCheck.ts
@@ -7,6 +7,10 @@ type ReleasePayload = {
   tag_name?: string
 }
 
+type PullRequestFilePayload = {
+  filename?: string
+}
+
 const readJson = <T>(filePath: string): T => {
   const raw = fs.readFileSync(filePath, 'utf-8')
   return JSON.parse(raw) as T
@@ -20,12 +24,12 @@ const cleanVersion = (value: string, label: string): string => {
   return cleaned
 }
 
-const getLatestReleaseTag = async (repo: string, token: string): Promise<string> => {
+const githubGet = async <T>(pathName: string, token: string): Promise<T> => {
   return await new Promise((resolve, reject) => {
     const request = https.request(
       {
         hostname: 'api.github.com',
-        path: `/repos/${repo}/releases/latest`,
+        path: pathName,
         headers: {
           'User-Agent': 'version-check',
           'Authorization': `token ${token}`,
@@ -38,17 +42,16 @@ const getLatestReleaseTag = async (repo: string, token: string): Promise<string>
           data += String(chunk)
         })
         res.on('end', () => {
-          if (res.statusCode !== 200) {
+          if ((res.statusCode ?? 500) >= 300) {
             reject(new Error(`GitHub API error: ${res.statusCode ?? 'unknown'} ${data}`))
             return
           }
-          const payload = JSON.parse(data) as ReleasePayload
-          const tag = String(payload.tag_name ?? '').trim()
-          if (!tag) {
-            reject(new Error('Latest release tag not found'))
-            return
+
+          try {
+            resolve(JSON.parse(data) as T)
+          } catch (error) {
+            reject(error)
           }
-          resolve(tag.replace(/^v/, ''))
         })
       }
     )
@@ -60,11 +63,70 @@ const getLatestReleaseTag = async (repo: string, token: string): Promise<string>
   })
 }
 
+const getLatestReleaseTag = async (repo: string, token: string): Promise<string> => {
+  const payload = await githubGet<ReleasePayload>(`/repos/${repo}/releases/latest`, token)
+  const tag = String(payload.tag_name ?? '').trim()
+  if (!tag) {
+    throw new Error('Latest release tag not found')
+  }
+  return tag.replace(/^v/, '')
+}
+
+const getPullRequestNumber = (): number | undefined => {
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    return undefined
+  }
+
+  const eventPayload = readJson<{ pull_request?: { number?: number } }>(eventPath)
+  const prNumber = eventPayload.pull_request?.number
+  return typeof prNumber === 'number' ? prNumber : undefined
+}
+
+const getPullRequestFiles = async (repo: string, prNumber: number, token: string): Promise<string[]> => {
+  const files: string[] = []
+  let page = 1
+
+  while (true) {
+    const payload = await githubGet<PullRequestFilePayload[]>(`/repos/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`, token)
+    if (!Array.isArray(payload) || payload.length === 0) {
+      break
+    }
+
+    for (const file of payload) {
+      const filename = String(file.filename ?? '').trim()
+      if (filename) {
+        files.push(filename)
+      }
+    }
+
+    if (payload.length < 100) {
+      break
+    }
+    page += 1
+  }
+
+  return files
+}
+
+const requiresVersionBump = (changedFiles: string[]): boolean => {
+  return changedFiles.some((file) => file === 'package.json' || file === 'package-lock.json' || file.startsWith('library/'))
+}
+
 const main = async (): Promise<void> => {
   const repo = process.env.GITHUB_REPOSITORY
   const token = process.env.GITHUB_TOKEN
   if (!repo) throw new Error('GITHUB_REPOSITORY not set')
   if (!token) throw new Error('GITHUB_TOKEN not set')
+
+  const prNumber = getPullRequestNumber()
+  if (prNumber) {
+    const changedFiles = await getPullRequestFiles(repo, prNumber, token)
+    if (!requiresVersionBump(changedFiles)) {
+      console.log(`OK: skipping version bump check for PR #${prNumber}; no publishable package files changed`)
+      return
+    }
+  }
 
   const repoRoot = path.resolve(__dirname, '..')
   const rootPkg = readJson<{ version?: string }>(path.join(repoRoot, 'package.json'))
@@ -74,15 +136,9 @@ const main = async (): Promise<void> => {
   const latest = await getLatestReleaseTag(repo, token)
   const currentVersion = cleanVersion(current, 'package.json')
   const latestVersion = cleanVersion(latest, 'latest release tag')
-  if (semver.lt(currentVersion, latestVersion)) {
-    throw new Error(`package.json version (${current}) must not be lower than latest release (${latest})`)
+  if (!semver.gt(currentVersion, latestVersion)) {
+    throw new Error(`package.json version (${current}) must be greater than latest release (${latest})`)
   }
-
-  if (semver.eq(currentVersion, latestVersion)) {
-    console.log(`OK: package.json version (${current}) matches latest release (${latest}); no version bump required for this PR`)
-    return
-  }
-
   console.log(`OK: package.json version (${current}) is greater than latest release (${latest})`)
 }
 

--- a/scripts/premergeVersionCheck.ts
+++ b/scripts/premergeVersionCheck.ts
@@ -74,9 +74,15 @@ const main = async (): Promise<void> => {
   const latest = await getLatestReleaseTag(repo, token)
   const currentVersion = cleanVersion(current, 'package.json')
   const latestVersion = cleanVersion(latest, 'latest release tag')
-  if (!semver.gt(currentVersion, latestVersion)) {
-    throw new Error(`package.json version (${current}) must be greater than latest release (${latest})`)
+  if (semver.lt(currentVersion, latestVersion)) {
+    throw new Error(`package.json version (${current}) must not be lower than latest release (${latest})`)
   }
+
+  if (semver.eq(currentVersion, latestVersion)) {
+    console.log(`OK: package.json version (${current}) matches latest release (${latest}); no version bump required for this PR`)
+    return
+  }
+
   console.log(`OK: package.json version (${current}) is greater than latest release (${latest})`)
 }
 

--- a/scripts/premergeVersionCheck.ts
+++ b/scripts/premergeVersionCheck.ts
@@ -7,10 +7,6 @@ type ReleasePayload = {
   tag_name?: string
 }
 
-type PullRequestFilePayload = {
-  filename?: string
-}
-
 const readJson = <T>(filePath: string): T => {
   const raw = fs.readFileSync(filePath, 'utf-8')
   return JSON.parse(raw) as T
@@ -24,12 +20,12 @@ const cleanVersion = (value: string, label: string): string => {
   return cleaned
 }
 
-const githubGet = async <T>(pathName: string, token: string): Promise<T> => {
+const getLatestReleaseTag = async (repo: string, token: string): Promise<string> => {
   return await new Promise((resolve, reject) => {
     const request = https.request(
       {
         hostname: 'api.github.com',
-        path: pathName,
+        path: `/repos/${repo}/releases/latest`,
         headers: {
           'User-Agent': 'version-check',
           'Authorization': `token ${token}`,
@@ -42,16 +38,17 @@ const githubGet = async <T>(pathName: string, token: string): Promise<T> => {
           data += String(chunk)
         })
         res.on('end', () => {
-          if ((res.statusCode ?? 500) >= 300) {
+          if (res.statusCode !== 200) {
             reject(new Error(`GitHub API error: ${res.statusCode ?? 'unknown'} ${data}`))
             return
           }
-
-          try {
-            resolve(JSON.parse(data) as T)
-          } catch (error) {
-            reject(error)
+          const payload = JSON.parse(data) as ReleasePayload
+          const tag = String(payload.tag_name ?? '').trim()
+          if (!tag) {
+            reject(new Error('Latest release tag not found'))
+            return
           }
+          resolve(tag.replace(/^v/, ''))
         })
       }
     )
@@ -63,70 +60,11 @@ const githubGet = async <T>(pathName: string, token: string): Promise<T> => {
   })
 }
 
-const getLatestReleaseTag = async (repo: string, token: string): Promise<string> => {
-  const payload = await githubGet<ReleasePayload>(`/repos/${repo}/releases/latest`, token)
-  const tag = String(payload.tag_name ?? '').trim()
-  if (!tag) {
-    throw new Error('Latest release tag not found')
-  }
-  return tag.replace(/^v/, '')
-}
-
-const getPullRequestNumber = (): number | undefined => {
-  const eventPath = process.env.GITHUB_EVENT_PATH
-  if (!eventPath || !fs.existsSync(eventPath)) {
-    return undefined
-  }
-
-  const eventPayload = readJson<{ pull_request?: { number?: number } }>(eventPath)
-  const prNumber = eventPayload.pull_request?.number
-  return typeof prNumber === 'number' ? prNumber : undefined
-}
-
-const getPullRequestFiles = async (repo: string, prNumber: number, token: string): Promise<string[]> => {
-  const files: string[] = []
-  let page = 1
-
-  while (true) {
-    const payload = await githubGet<PullRequestFilePayload[]>(`/repos/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`, token)
-    if (!Array.isArray(payload) || payload.length === 0) {
-      break
-    }
-
-    for (const file of payload) {
-      const filename = String(file.filename ?? '').trim()
-      if (filename) {
-        files.push(filename)
-      }
-    }
-
-    if (payload.length < 100) {
-      break
-    }
-    page += 1
-  }
-
-  return files
-}
-
-const requiresVersionBump = (changedFiles: string[]): boolean => {
-  return changedFiles.some((file) => file === 'package.json' || file === 'package-lock.json' || file.startsWith('library/'))
-}
-
 const main = async (): Promise<void> => {
   const repo = process.env.GITHUB_REPOSITORY
   const token = process.env.GITHUB_TOKEN
   if (!repo) throw new Error('GITHUB_REPOSITORY not set')
   if (!token) throw new Error('GITHUB_TOKEN not set')
-
-  const prNumber = getPullRequestNumber()
-  if (prNumber) {
-    const changedFiles = await getPullRequestFiles(repo, prNumber, token)
-    if (!requiresVersionBump(changedFiles)) {
-      console.log(`OK: skipping version bump check for PR #${prNumber}; no publishable package files changed`)
-      return
-    }
-  }
 
   const repoRoot = path.resolve(__dirname, '..')
   const rootPkg = readJson<{ version?: string }>(path.join(repoRoot, 'package.json'))


### PR DESCRIPTION
### Motivation
- Ensure releases are published to both `npmjs.com` and the Connected Web GitHub Packages registry so the scoped package appears in the `connected-web` org on GitHub.
- Allow the release workflow to authenticate and publish to GitHub Packages using the workflow token by granting the necessary `packages: write` permission.

### Description
- Add `packages: write` to the job `permissions` in `.github/workflows/publish.yml` to permit publishing to GitHub Packages.
- Add a second `actions/setup-node@v6` step configured with `registry-url: 'https://npm.pkg.github.com'` and `scope: '@connected-web'` to configure npm for the GitHub Packages registry.
- Add a new step that runs `npm publish --registry https://npm.pkg.github.com --access public` with `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` after the existing `npm publish --provenance --access public` to publish to both registries.

### Testing
- Ran `git diff -- .github/workflows/publish.yml` to verify the workflow diff and confirm the changes were applied, which succeeded.
- Attempted a local YAML parse with `python - <<'PY' ... yaml.safe_load(...)` which failed due to the environment missing the `PyYAML` module (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4e5d157c8331903f49281814dbae)